### PR TITLE
feat: urlをParamsUrl形式に変換し、返す関数を定義 #55

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func ParamsUrl(q string, baseURL string) string {
+	params := url.Values{}
+	params.Set("q", q)
+	params.Set("type", "track")
+	params.Set("market", "JP")
+	fullURL := fmt.Sprintf("%s?%s", baseURL, params.Encode())
+	
+	return fullURL
+}


### PR DESCRIPTION
### Ticket
- issures番号
  - #55

### What
- 実装内容
  - urlをParamsUrl形式に変換し、返す関数を定義

### Why
- 実装背景
  - 利便性向上のため

## Check
- [x] 最終確認

